### PR TITLE
受け取ったメッセージによって処理を分岐できるように下準備をしました

### DIFF
--- a/src/__tests__/unit/lib/message_builder_spec.js
+++ b/src/__tests__/unit/lib/message_builder_spec.js
@@ -1,0 +1,29 @@
+'use strict';
+const MessageBuilder = require('../../../lib/message_builder');
+
+describe('message_builderのtest', () => {
+    it('text型のMessageEventでtextのレスポンスメッセージが生成されること', () => {
+        const msg = MessageBuilder.build({
+            type: 'message',
+            message: { type: 'text', id: 1234, text: 'hello' },
+        });
+        expect(msg.type).toBe('text');
+    });
+
+    it('未定義のMessageEventでは、textのレスポンスメッセージが生成されること', () => {
+        const msg = MessageBuilder.build({
+            type: 'message',
+            message: { type: 'image', id: 1234 },
+        });
+        expect(msg.type).toBe('text');
+    });
+
+    it('MessageEventっぽい違うオブジェクトが渡された場合、textのレスポンスメッセージが生成されること', () => {
+        // 使い方を間違えた場合を想定
+        const msg = MessageBuilder.build({
+            type: 'message',
+            message: { id: 1234 },
+        });
+        expect(msg.type).toBe('text');
+    });
+});

--- a/src/__tests__/unit/lib/message_event_spec.js
+++ b/src/__tests__/unit/lib/message_event_spec.js
@@ -5,10 +5,10 @@ describe('message_eventのテスト', () => {
     it('LINEのMessageEventであればparseできること', () => {
         const actual = new MessageEvent({
             type: 'message',
-            message: { id: 1234, text: 'hello' },
+            message: { id: 1234, text: 'hello', type: 'text' },
         });
 
-        expect(actual.type).toBe('message');
+        expect(actual.type).toBe('text');
         expect(actual.id).toBe(1234);
     });
 

--- a/src/__tests__/unit/lib/message_event_spec.js
+++ b/src/__tests__/unit/lib/message_event_spec.js
@@ -1,0 +1,20 @@
+'use strict';
+const MessageEvent = require('../../../lib/message_event');
+
+describe('message_eventのテスト', () => {
+    it('LINEのMessageEventであればparseできること', () => {
+        const actual = new MessageEvent({
+            type: 'message',
+            message: { id: 1234, text: 'hello' },
+        });
+
+        expect(actual.type).toBe('message');
+        expect(actual.id).toBe(1234);
+    });
+
+    it('LINEのMessageEventでない場合、例外が発生すること', () => {
+        expect(() => {
+            new MessageEvent({});
+        }).toThrow('cannot generate message event');
+    });
+});

--- a/src/__tests__/unit/lib/text_message_event_spec.js
+++ b/src/__tests__/unit/lib/text_message_event_spec.js
@@ -1,0 +1,24 @@
+'use strict';
+const TextMessageEvent = require('../../../lib/text_message_event');
+
+describe('text_message_eventのテスト', () => {
+    it('LINEのMessageEventがtextタイプであればparseできること', () => {
+        const actual = new TextMessageEvent({
+            type: 'message',
+            message: { type: 'text', id: 1234, text: 'hello' },
+        });
+
+        expect(actual.type).toBe('message');
+        expect(actual.id).toBe(1234);
+        expect(actual.text).toBe('hello');
+    });
+
+    it('LINEのMessageEventがtextタイプ以外のとき例外が発生すること', () => {
+        expect(() => {
+            new TextMessageEvent({
+                type: 'message',
+                message: { type: 'image', id: 1234 },
+            });
+        }).toThrow('text type MessageEvent only');
+    });
+});

--- a/src/__tests__/unit/lib/text_message_event_spec.js
+++ b/src/__tests__/unit/lib/text_message_event_spec.js
@@ -8,7 +8,7 @@ describe('text_message_eventのテスト', () => {
             message: { type: 'text', id: 1234, text: 'hello' },
         });
 
-        expect(actual.type).toBe('message');
+        expect(actual.type).toBe('text');
         expect(actual.id).toBe(1234);
         expect(actual.text).toBe('hello');
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const channelSecret = process.env.CHANNEL_SEACREST || 'dummuy';
 const line = require('@line/bot-sdk');
-const lineHelper = require('./lib/line_helper');
+const MessageBuilder = require('./lib/message_builder');
 
 module.exports.handler = async (event, context, callback) => {
     const body = event.body;
@@ -20,7 +20,7 @@ module.exports.handler = async (event, context, callback) => {
     try {
         client.replyMessage(
             JSON.parse(event.body).events[0].replyToken,
-            lineHelper.buildTextMessage(JSON.parse(event.body).events[0].message.text)
+            MessageBuilder.build(JSON.parse(event.body).events[0])
         );
     } catch (err) {
         console.log(err.message);

--- a/src/lib/message_builder.js
+++ b/src/lib/message_builder.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const TextMessageEvent = require('./text_message_event');
+const LineHelper = require('./line_helper');
+
+module.exports = class MessageBuilder {
+    static build(event) {
+        const type = !event.message.type ? 'unknown' : event.message.type;
+
+        let message = {};
+        if (type === 'text') {
+            const textMessage = new TextMessageEvent(event);
+            message = LineHelper.buildTextMessage(textMessage.text);
+        } else {
+            message = LineHelper.buildTextMessage('unknow type was recieved...');
+        }
+        return message;
+    }
+};

--- a/src/lib/message_event.js
+++ b/src/lib/message_event.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = class MessageEvent {
+    constructor(event) {
+        if (!event.type || event.type !== 'message') {
+            throw new Error('cannot generate message event');
+        }
+        this.type_ = event.type;
+        this.id_ = event.message.id;
+    }
+
+    get type() {
+        return this.type_;
+    }
+
+    get id() {
+        return this.id_;
+    }
+};

--- a/src/lib/message_event.js
+++ b/src/lib/message_event.js
@@ -5,7 +5,7 @@ module.exports = class MessageEvent {
         if (!event.type || event.type !== 'message') {
             throw new Error('cannot generate message event');
         }
-        this.type_ = event.type;
+        this.type_ = event.message.type;
         this.id_ = event.message.id;
     }
 

--- a/src/lib/text_message_event.js
+++ b/src/lib/text_message_event.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const MessageEvent = require('./message_event');
+
+module.exports = class TextMessageEvent extends MessageEvent {
+    constructor(event) {
+        super(event);
+        if (event.message.type !== 'text') {
+            throw new Error('text type MessageEvent only');
+        }
+        this.text_ = event.message.text;
+    }
+
+    get text() {
+        return this.text_;
+    }
+};


### PR DESCRIPTION
## PR内容
掲題の通りです。
通常のテキスト、位置情報、画像などいくつかのメッセージの種類を受け取るので
どういうレスポンスを返すかは別のメソッドに切り出しました。

indexではeventを渡してレスポンスを生成するというシンプルな流れになります。

## 変更点
* 基底となるMessageEventクラスを追加
* MessageEventを継承したtextタイプのクラスを追加
* message builderを追加し、indexの処理を単純化
* message builderのテストを追加