### PR TITLE
テンプレートメッセージを返せるようにしました

### DIFF
--- a/src/__tests__/unit/lib/line_helper_spec.js
+++ b/src/__tests__/unit/lib/line_helper_spec.js
@@ -19,4 +19,30 @@ describe('line_helperのtest', () => {
             previewImageUrl: 'preUrl',
         });
     });
+
+    it('buildConfirmTemplateMessageでconfirm形式のメッセージが生成できること', () => {
+        const choices = [
+            {
+                type: 'message',
+                label: 'Hoge',
+                text: 'hoge',
+            },
+            {
+                type: 'message',
+                label: 'BAR',
+                text: 'bar',
+            },
+        ];
+
+        const actual = lineHelper.buildConfirmTemplateMessage(choices);
+        expect(actual).toEqual({
+            type: 'template',
+            altText: 'this is a confirm template',
+            template: {
+                type: 'confirm',
+                text: 'Are you sure?',
+                actions: choices,
+            },
+        });
+    });
 });

--- a/src/__tests__/unit/lib/message_builder_spec.js
+++ b/src/__tests__/unit/lib/message_builder_spec.js
@@ -2,12 +2,22 @@
 const MessageBuilder = require('../../../lib/message_builder');
 
 describe('message_builderのtest', () => {
-    it('text型のMessageEventでtextのレスポンスメッセージが生成されること', () => {
-        const msg = MessageBuilder.build({
-            type: 'message',
-            message: { type: 'text', id: 1234, text: 'hello' },
+    describe('text型のテスト', () => {
+        it('text型のMessageEventでtextのレスポンスメッセージが生成されること', () => {
+            const msg = MessageBuilder.build({
+                type: 'message',
+                message: { type: 'text', id: 1234, text: 'confirm' },
+            });
+            expect(msg.type).toBe('template');
         });
-        expect(msg.type).toBe('text');
+
+        it('特定のtextの場合、confirmTemplateの形式のメッセージが生成されること', () => {
+            const msg = MessageBuilder.build({
+                type: 'message',
+                message: { type: 'text', id: 1234, text: 'hello' },
+            });
+            expect(msg.type).toBe('text');
+        });
     });
 
     it('未定義のMessageEventでは、textのレスポンスメッセージが生成されること', () => {

--- a/src/lib/line_helper.js
+++ b/src/lib/line_helper.js
@@ -17,4 +17,17 @@ module.exports = class LineHelper {
         };
         return imageMessage;
     }
+
+    static buildConfirmTemplateMessage(choices, confirmText = 'Are you sure?') {
+        const confirmMessage = {
+            type: 'template',
+            altText: 'this is a confirm template',
+            template: {
+                type: 'confirm',
+                text: confirmText,
+                actions: choices,
+            },
+        };
+        return confirmMessage;
+    }
 };

--- a/src/lib/message_builder.js
+++ b/src/lib/message_builder.js
@@ -10,7 +10,22 @@ module.exports = class MessageBuilder {
         let message = {};
         if (type === 'text') {
             const textMessage = new TextMessageEvent(event);
-            message = LineHelper.buildTextMessage(textMessage.text);
+            if (textMessage.text === 'confirm') {
+                message = LineHelper.buildConfirmTemplateMessage([
+                    {
+                        type: 'message',
+                        label: 'Yes',
+                        text: 'yes',
+                    },
+                    {
+                        type: 'message',
+                        label: 'No',
+                        text: 'no',
+                    },
+                ]);
+            } else {
+                message = LineHelper.buildTextMessage(textMessage.text);
+            }
         } else {
             message = LineHelper.buildTextMessage('unknow type was recieved...');
         }


### PR DESCRIPTION
## PR内容
掲題の通りです。

confirmという特定の文字列を送ったときのみ、
confirmテンプレート形式でメッセージが送信されます。
![img_7583](https://user-images.githubusercontent.com/10177370/42852468-b07ec008-8a6b-11e8-8c5b-f98d67a98eb8.PNG)

## 変更点
* テンプレート形式のメッセージを生成できるように拡張
* message-builderの条件分岐を追加
* テストを追加
